### PR TITLE
US-52: Remove Dimensions Parameter From ABody Hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,3 +531,26 @@ the body I think changes should be made
 
 #### Tutorial
 This user story does not require a tutorial
+
+---
+
+### US-52: Remove Dimensions Parameter From ABody Hierarchy
+Date completed: 22/11/2023
+Completed by: Erik Andreasson
+
+As a developer I want to remove the dimensions parameter from the ABody hierarchy because it is confusing and unnecessary to the MVP
+
+This parameter has been an issue in the codebase for some time. It is confusing and not necessary to the code.
+
+#### What
+This user story was about removing an unneeded and confusing parameter from the ABody hierarchy in order to clean up the code
+and make tests easier to write
+
+#### How
+I used the inbuilt refactor tool in Intellij to change the signature throughout the codebase
+
+#### Why
+No specific design choices were made in implementing this user story
+
+#### Tutorial
+This user story does not require a tutorial

--- a/sailinggame/src/main/java/com/group11/model/ABody.java
+++ b/sailinggame/src/main/java/com/group11/model/ABody.java
@@ -16,13 +16,12 @@ public abstract class ABody extends APositonable implements IDamageable {
 
     /**
      * Constructor for creating objects of type ABody, the physical part of an entity in the game.
-     * @param dimension - the dimension of the body
+     *
      * @param pos       - the position of the body in the tilemap
      * @param hitPoints - the hitpoints of the body
      */
-    protected ABody(ArrayList<ArrayList<Boolean>> dimensions, Point pos, int hitPoints, String description) {
+    protected ABody(Point pos, int hitPoints, String description) {
         super(pos);
-        this.dimensions = dimensions;
         this.hitPoints  = hitPoints;
     }
 

--- a/sailinggame/src/main/java/com/group11/model/ABody.java
+++ b/sailinggame/src/main/java/com/group11/model/ABody.java
@@ -9,8 +9,6 @@ import java.util.ArrayList;
  */
 
 public abstract class ABody extends APositonable implements IDamageable {
-
-    private ArrayList<ArrayList<Boolean>> dimensions;
     private int hitPoints;
     String description;
 
@@ -48,21 +46,5 @@ public abstract class ABody extends APositonable implements IDamageable {
      */
     public void setHitPoints(int newHitpoints) {
         this.hitPoints = newHitpoints;
-    }
-
-    /**
-     * 
-     * @return dimensions of an object.
-     */
-    public ArrayList<ArrayList<Boolean>> getDimensions() {
-        return dimensions;
-    }
-    
-    /**
-     * 
-     * @param dimensions desired body dimensions.
-     */
-    public void setDimensions(ArrayList<ArrayList<Boolean>> dimensions) {
-        this.dimensions = dimensions;
     }
 }

--- a/sailinggame/src/main/java/com/group11/model/AImmovableBody.java
+++ b/sailinggame/src/main/java/com/group11/model/AImmovableBody.java
@@ -1,7 +1,6 @@
 package com.group11.model;
 
 import java.awt.Point;
-import java.util.ArrayList;
 
 /**
  * A class representing a body that doesnt move, such as cities and other locations.
@@ -10,13 +9,13 @@ public class AImmovableBody extends ABody {
 
     /**
      * Constructor for creating immovable bodies
-     * @param dimensions The physical dimensions of the body
-     * @param pos The position of the body on the map
+     *
+     * @param pos       The position of the body on the map
      * @param hitPoints The hitpoints of the body
      * @param textureId The id represnting the texture of the body
      */
-    protected AImmovableBody(ArrayList<ArrayList<Boolean>> dimensions, Point pos, int hitPoints, int textureId, String description) {
-        super(dimensions, pos, hitPoints, description);
+    protected AImmovableBody(Point pos, int hitPoints, int textureId, String description) {
+        super(pos, hitPoints, description);
     }
     
 }

--- a/sailinggame/src/main/java/com/group11/model/AMovableBody.java
+++ b/sailinggame/src/main/java/com/group11/model/AMovableBody.java
@@ -1,7 +1,6 @@
 package com.group11.model;
 
 import java.awt.Point;
-import java.util.ArrayList;
 
 /**
  * Abstract class representing an abstract movable body. This class extends ABody and implements the IMovable interface
@@ -14,12 +13,11 @@ public abstract class AMovableBody extends ABody implements IMovable {
 
     /**
      * Constructor for a movable body, like a body but its meant to move around the game world.
-     * @param dimensions The dimensions of the body represented as a matrix of true (uses that square) or false (does not use that square)
-     * @param pos The starting position of the body as a Java Point
-     * @param hitPoints The hitpooints of the body
+     * @param pos       The starting position of the body as a Java Point
+     * @param hitPoints The hitpoints of the body
      */
-    protected AMovableBody(ArrayList<ArrayList<Boolean>> dimensions, Point pos, int hitPoints, String description){
-        super(dimensions, pos, hitPoints, description);
+    protected AMovableBody(Point pos, int hitPoints, String description){
+        super(pos, hitPoints, description);
         this.velocity = 0;
     }
 

--- a/sailinggame/src/main/java/com/group11/model/Ship.java
+++ b/sailinggame/src/main/java/com/group11/model/Ship.java
@@ -1,7 +1,6 @@
 package com.group11.model;
 
 import java.awt.Point;
-import java.util.ArrayList;
 
 /**
  * Class representing a ship. This class extends AMovableBody.
@@ -16,13 +15,13 @@ public class Ship extends AMovableBody implements HasWeapon {
 
     /**
      * Constructor for creating objects of type AShip.
-     * @param shipLevel   - the level of the ship
-     * @param armor       - the armor of the ship
-     * @param cannons     - the cannons of the ship
-     * @param sailStatus  - the sail status. Either up (true) or down (false)
+     *
+     * @param shipLevel  - the level of the ship
+     * @param armor      - the armor of the ship
+     * @param cannons    - the cannons of the ship
      */
-    public Ship(ArrayList<ArrayList<Boolean>> dimensions, Point pos, int shipLevel, int armor, int cannons, int hitPoints){
-        super(dimensions, pos, hitPoints, "A basic ship");
+    public Ship(Point pos, int shipLevel, int armor, int cannons, int hitPoints){
+        super(pos, hitPoints, "A basic ship");
         this.shipLevel   = shipLevel;
         this.armor       = armor;
         this.cannons     = cannons;
@@ -63,8 +62,7 @@ public class Ship extends AMovableBody implements HasWeapon {
 
     /**
      * Fires the cannon of the ship
-     *
-     * @param damage - the amount of damage the cannon does
+     * @param direction to fire the weapon
      */
     public void fireCannons(int direction){
         //Not implemented in the current state of the game, view this as a placeholder

--- a/sailinggame/src/main/java/com/group11/model/StandardMovableEntityFactory.java
+++ b/sailinggame/src/main/java/com/group11/model/StandardMovableEntityFactory.java
@@ -14,7 +14,7 @@ public class StandardMovableEntityFactory implements IMovableEntityFactory {
      */
     public AEntity createPlayer() {
         ArrayList<ArrayList<Boolean>> dimensions = createDimensions(1);
-        return new PlayableEntity(new Ship(dimensions, new Point(0,0), 0, 0 ,0 ,0), "player");
+        return new PlayableEntity(new Ship(new Point(0,0), 0, 0 ,0 ,0), "player");
     }
 
     /**

--- a/sailinggame/src/test/java/ABodyTest.java
+++ b/sailinggame/src/test/java/ABodyTest.java
@@ -9,7 +9,7 @@ import java.awt.*;
 public class ABodyTest {
 
     Point testPosition = new Point(10, 20);
-    Ship testShip = new Ship(null, testPosition, 0, 0, 0, 2); 
+    Ship testShip = new Ship(testPosition, 0, 0, 0, 2);
 
     @Test
     public void testTakeDamage() {

--- a/sailinggame/src/test/java/AMovableBodyTest.java
+++ b/sailinggame/src/test/java/AMovableBodyTest.java
@@ -9,7 +9,7 @@ import java.awt.*;
 public class AMovableBodyTest {
 
     Point position = new Point(10,10);
-    Ship testShip = new Ship(null, position, 0, 0, 0, 2);
+    Ship testShip = new Ship(position, 0, 0, 0, 2);
 
     @Test
     public void testMove() {

--- a/sailinggame/src/test/java/PlayableEntityTest.java
+++ b/sailinggame/src/test/java/PlayableEntityTest.java
@@ -19,7 +19,7 @@ public class PlayableEntityTest {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
         
-        Ship testShip = new Ship(null, new Point(0,0), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(0,0), 0, 0, 0, 2);
         PlayableEntity player = new PlayableEntity(testShip, "testy mcTest");
         
         //Starting position is (0,0) which is the bottom left corner of the map
@@ -37,7 +37,7 @@ public class PlayableEntityTest {
     public void testMoveUp() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(0,0), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(0,0), 0, 0, 0, 2);
         PlayableEntity player = new PlayableEntity(testShip, "testy mcTest");
         player.moveCommand(0);
         int playerY = (int) player.getPos().getY();
@@ -50,7 +50,7 @@ public class PlayableEntityTest {
     public void testMoveUpRightAngle() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(0,0), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(0,0), 0, 0, 0, 2);
         PlayableEntity player = new PlayableEntity(testShip, "testy mcTest");
         player.moveCommand(1);
         int playerY = (int) player.getPos().getY();
@@ -63,7 +63,7 @@ public class PlayableEntityTest {
     public void testMoveRight() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(0,0), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(0,0), 0, 0, 0, 2);
         PlayableEntity player = new PlayableEntity(testShip, "testy mcTest");
         player.moveCommand(2);
         int playerY = (int) player.getPos().getY();
@@ -76,7 +76,7 @@ public class PlayableEntityTest {
     public void testMoveDownRightAngle() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(2,2), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(2,2), 0, 0, 0, 2);
         PlayableEntity player = new PlayableEntity(testShip, "testy mcTest");
         player.moveCommand(3);
         int playerY = (int) player.getPos().getY();
@@ -89,7 +89,7 @@ public class PlayableEntityTest {
     public void testMoveDown() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(2,2), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(2,2), 0, 0, 0, 2);
         PlayableEntity player = new PlayableEntity(testShip, "testy mcTest");
         player.moveCommand(4);
         int playerY = (int) player.getPos().getY();
@@ -102,7 +102,7 @@ public class PlayableEntityTest {
     public void testMoveDownLeftAngle() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(2,2), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(2,2), 0, 0, 0, 2);
         PlayableEntity player = new PlayableEntity(testShip, "testy mcTest");
         player.moveCommand(5);
         int playerY = (int) player.getPos().getY();
@@ -115,7 +115,7 @@ public class PlayableEntityTest {
     public void testMoveLeft() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(2,2), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(2,2), 0, 0, 0, 2);
         PlayableEntity player = new PlayableEntity(testShip, "testy mcTest");
         player.moveCommand(6);
         int playerY = (int) player.getPos().getY();
@@ -128,7 +128,7 @@ public class PlayableEntityTest {
     public void testMoveUpLeftAngle() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(2,2), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(2,2), 0, 0, 0, 2);
         PlayableEntity player = new PlayableEntity(testShip, "testy mcTest");
         player.moveCommand(7);
         int playerY = (int) player.getPos().getY();

--- a/sailinggame/src/test/java/ShipTest.java
+++ b/sailinggame/src/test/java/ShipTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.*;
 
 public class ShipTest {
 
-    Ship testShip = new Ship(null, null, 0, 0, 0, 2);
+    Ship testShip = new Ship(null, 0, 0, 0, 2);
 
     @Test
     public void testAnchor() {

--- a/sailinggame/src/test/java/UnplayableEntityTest.java
+++ b/sailinggame/src/test/java/UnplayableEntityTest.java
@@ -13,7 +13,7 @@ public class UnplayableEntityTest {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
 
-        Ship testShip = new Ship(null, new Point(0,0), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(0,0), 0, 0, 0, 2);
         UnplayableEntity entity = new UnplayableEntity(testShip, "testy mcTest", true);
 
         //Starting position is (0,0) which is the bottom left corner of the map
@@ -31,7 +31,7 @@ public class UnplayableEntityTest {
     public void testMoveUp() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(0,0), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(0,0), 0, 0, 0, 2);
         UnplayableEntity entity = new UnplayableEntity(testShip, "testy mcTest", true);
         entity.moveCommand(0);
         int entityY = (int) entity.getPos().getY();
@@ -44,7 +44,7 @@ public class UnplayableEntityTest {
     public void testMoveUpRightAngle() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(0,0), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(0,0), 0, 0, 0, 2);
         UnplayableEntity entity = new UnplayableEntity(testShip, "testy mcTest", true);
         entity.moveCommand(1);
         int entityY = (int) entity.getPos().getY();
@@ -57,7 +57,7 @@ public class UnplayableEntityTest {
     public void testMoveRight() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(0,0), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(0,0), 0, 0, 0, 2);
         UnplayableEntity entity = new UnplayableEntity(testShip, "testy mcTest", true);
         entity.moveCommand(2);
         int entityY = (int) entity.getPos().getY();
@@ -70,7 +70,7 @@ public class UnplayableEntityTest {
     public void testMoveDownRightAngle() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(2,2), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(2,2), 0, 0, 0, 2);
         UnplayableEntity entity = new UnplayableEntity(testShip, "testy mcTest", true);
         entity.moveCommand(3);
         int entityY = (int) entity.getPos().getY();
@@ -83,7 +83,7 @@ public class UnplayableEntityTest {
     public void testMoveDown() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(2,2), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(2,2), 0, 0, 0, 2);
         UnplayableEntity entity = new UnplayableEntity(testShip, "testy mcTest", true);
         entity.moveCommand(4);
         int entityY = (int) entity.getPos().getY();
@@ -96,7 +96,7 @@ public class UnplayableEntityTest {
     public void testMoveDownLeftAngle() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(2,2), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(2,2), 0, 0, 0, 2);
         UnplayableEntity entity = new UnplayableEntity(testShip, "testy mcTest", true);
         entity.moveCommand(5);
         int entityY = (int) entity.getPos().getY();
@@ -109,7 +109,7 @@ public class UnplayableEntityTest {
     public void testMoveLeft() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(2,2), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(2,2), 0, 0, 0, 2);
         UnplayableEntity entity = new UnplayableEntity(testShip, "testy mcTest", true);
         entity.moveCommand(6);
         int entityY = (int) entity.getPos().getY();
@@ -122,7 +122,7 @@ public class UnplayableEntityTest {
     public void testMoveUpLeftAngle() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setMap(map);
-        Ship testShip = new Ship(null, new Point(2,2), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(2,2), 0, 0, 0, 2);
         UnplayableEntity entity = new UnplayableEntity(testShip, "testy mcTest", true);
         entity.moveCommand(7);
         int entityY = (int) entity.getPos().getY();


### PR DESCRIPTION
As a developer I want to remove the dimensions parameter from the ABody hierarchy because it is confusing and unnecessary to the MVP

This parameter has been an issue in the codebase for some time. It is confusing and not necessary to the code.