### PR TITLE
US-59: Fix Directional Vectors In CommandableEntity Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,4 +699,25 @@ body or not. However, that may be viewed as somewhat of a stretch.
 
 #### Tutorial
 This user story does not require a tutorial since it is for the developer.
->>>>>>> 2af6013a274ac3dde6f3a6cd9ead3fb95583cd57
+
+---
+
+### US-59: Fix Directional Vectors In CommandableEntity Methods
+Date of completion: 23/11/2023
+Completed by: Erik Andreasson
+
+#### What
+This user story is a small bug fix where the directional vectors in the methods moveCommand and attackCommand had the wrong
+values. There was a problem where when we wanted to move the body down it instead moved up since (0,0) is top left of map
+and not bottom left of map.
+
+#### How
+I simply switched some values around and rewrote the tests to reflect the change
+
+#### Why
+No specific design choices were made in this user story
+
+#### Tutorial
+This user story does not require a tutorial
+
+

--- a/sailinggame/src/main/java/com/group11/model/CommandableEntity.java
+++ b/sailinggame/src/main/java/com/group11/model/CommandableEntity.java
@@ -55,7 +55,7 @@ public class CommandableEntity extends AEntity implements ICommandable {
      */
     @Override
     public void moveCommand(Integer direction) {
-        int[][] directions = {{0,1}, {1,1}, {1,0}, {1,-1}, {0,-1}, {-1,-1}, {-1,0}, {-1,1}};
+        int[][] directions = {{0,-1}, {1,-1}, {1,0}, {1,1}, {0,1}, {-1,1}, {-1,0}, {-1,-1}};
         if (this.getBody() instanceof IMovable) {
             this.moveHelper(directions[direction]);
         } else {
@@ -69,7 +69,7 @@ public class CommandableEntity extends AEntity implements ICommandable {
      */
     @Override
     public void attackCommand(Integer direction) {
-        int[][] directions = {{0,1}, {1,1}, {1,0}, {1,-1}, {0,-1}, {-1,-1}, {-1,0}, {-1,1}};
+        int[][] directions = {{0,-1}, {1,-1}, {1,0}, {1,1}, {0,1}, {-1,1}, {-1,0}, {-1,-1}};
         if (this.getBody() instanceof HasWeapon) {
             ((HasWeapon) this.getBody()).fireWeapon(directions[direction]);
         } else {

--- a/sailinggame/src/test/java/CommandableEntityTest.java
+++ b/sailinggame/src/test/java/CommandableEntityTest.java
@@ -16,9 +16,9 @@ public class CommandableEntityTest {
         Ship testShip = new Ship(new Point(0,0), 0, 0, 0, 2);
         CommandableEntity entity = new CommandableEntity(testShip, "testy mcTest", true);
 
-        //Starting position is (0,0) which is the bottom left corner of the map
+        //Starting position is (0,0) which is the top left corner of the map
         for (int i = 0; i < 50; i++) { //Try to move entity to the top of the map. Through the big middle island created by BasicMapNGenerator.
-            entity.moveCommand(1); //1 is a right up diagonal move
+            entity.moveCommand(3); //1 is a right down diagonal move
         }
 
         int entityY = (int) entity.getPos().getY();
@@ -31,12 +31,12 @@ public class CommandableEntityTest {
     public void testMoveUp() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setTileMatrix(map.getTileMatrix());
-        Ship testShip = new Ship(new Point(0,0), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(0,1), 0, 0, 0, 2);
         CommandableEntity entity = new CommandableEntity(testShip, "testy mcTest", true);
         entity.moveCommand(0);
         int entityY = (int) entity.getPos().getY();
         int entityX = (int) entity.getPos().getX();
-        assertEquals(1, entityY);
+        assertEquals(0, entityY);
         assertEquals(0, entityX);
     }
 
@@ -44,13 +44,13 @@ public class CommandableEntityTest {
     public void testMoveUpRightAngle() {
         Map map = (new BasicMapGenerator()).generateMap(50);
         MovementUtility.setTileMatrix(map.getTileMatrix());
-        Ship testShip = new Ship(new Point(0,0), 0, 0, 0, 2);
+        Ship testShip = new Ship(new Point(1,1), 0, 0, 0, 2);
         CommandableEntity entity = new CommandableEntity(testShip, "testy mcTest", true);
         entity.moveCommand(1);
         int entityY = (int) entity.getPos().getY();
         int entityX = (int) entity.getPos().getX();
-        assertEquals(1, entityY);
-        assertEquals(1, entityX);
+        assertEquals(0, entityY);
+        assertEquals(2, entityX);
     }
 
     @Test
@@ -75,7 +75,7 @@ public class CommandableEntityTest {
         entity.moveCommand(3);
         int entityY = (int) entity.getPos().getY();
         int entityX = (int) entity.getPos().getX();
-        assertEquals(1, entityY);
+        assertEquals(3, entityY);
         assertEquals(3, entityX);
     }
 
@@ -88,7 +88,7 @@ public class CommandableEntityTest {
         entity.moveCommand(4);
         int entityY = (int) entity.getPos().getY();
         int entityX = (int) entity.getPos().getX();
-        assertEquals(1, entityY);
+        assertEquals(3, entityY);
         assertEquals(2, entityX);
     }
 
@@ -101,7 +101,7 @@ public class CommandableEntityTest {
         entity.moveCommand(5);
         int entityY = (int) entity.getPos().getY();
         int entityX = (int) entity.getPos().getX();
-        assertEquals(1, entityY);
+        assertEquals(3, entityY);
         assertEquals(1, entityX);
     }
 
@@ -127,7 +127,7 @@ public class CommandableEntityTest {
         entity.moveCommand(7);
         int entityY = (int) entity.getPos().getY();
         int entityX = (int) entity.getPos().getX();
-        assertEquals(3, entityY);
+        assertEquals(1, entityY);
         assertEquals(1, entityX);
     }
 


### PR DESCRIPTION
As a developer I want the moveCommand()/attackCommand() to use the correct vectors.