### PR TITLE
US-98: Create Lower Bound For Radius When Finding Player

### DIFF
--- a/README.md
+++ b/README.md
@@ -2137,3 +2137,30 @@ This makes the code less coupled and contributes to a more maintainable and modu
 
 #### User Interaction
 The user does not interact with this functionality, it is just to make the codebase more extendable.
+
+---
+
+### US-98: Create Lower Bound For Radius When Finding Player
+Date of completion: 7/12/2023  
+Completed by: Erik Andreasson
+
+As a player I don't want the enemy to be able to move into and on top of me because it makes the gameplay difficult
+
+#### What
+This user story is about creating an inner radius from the player to enemies so that enemies do not move into or too close
+to the player. 
+
+#### How
+I repurposed the unused method isNearPlayer to isNearEnemy by simply changing the if statement to search for the key "Enemy" instead of "Player".
+For this to work I rewrote the EntityDirector to set the name attribute for the enemy entity to simply "Entity", dropping the level value interpolation.
+This meant I had to rewrite a few tests. I then introduced a new if statement to the moveEnemies method checking if the enemy is too close
+to the player. If so the enemy chooses a random direction to move in.
+
+#### Why
+This user story was meant to enhance the gameplay and make the game easier for the player. Having the enemies hang around the player within a radius
+instead of moving on top of the player makes it easier to combat them. In regard to the code I simply repurposed existing code and added an if
+statement.
+
+#### User Interaction
+Once the enemy has reached a certain radius around the player they will no longer move directly toward the player. Instead moving randomly around
+them.

--- a/sailinggame/src/main/java/com/group11/application/SailingGameApplication.java
+++ b/sailinggame/src/main/java/com/group11/application/SailingGameApplication.java
@@ -94,8 +94,8 @@ public class SailingGameApplication extends AApplication {
                     this.waveNumber++;
                     this.enemyList = this.entitySpawner.createEnemyWave(this.waveNumber);
                 }
-                updatePlayer();
                 this.aiCommander.moveEnemies(this.enemyList);
+                updatePlayer();
                 this.updateEntityMatrix();
                 Thread.sleep(50);
 

--- a/sailinggame/src/main/java/com/group11/model/builders/EntityDirector.java
+++ b/sailinggame/src/main/java/com/group11/model/builders/EntityDirector.java
@@ -45,7 +45,7 @@ public class EntityDirector {
      */
     public AEntity createEnemy(Point position, int lvl) {
         builder.reset();
-        builder.setName(String.format("Enemy: lvl %d",lvl));
+        builder.setName(String.format("Enemy",lvl));
         builder.setFriendlyStatus(false);
         builder.setPosition(position);
         builder.setAttributesForLevel(lvl);

--- a/sailinggame/src/main/java/com/group11/model/utility/AICommander.java
+++ b/sailinggame/src/main/java/com/group11/model/utility/AICommander.java
@@ -72,9 +72,9 @@ public class AICommander {
     }
 
     /**
-     * Helper method checking if the input entity is in proximity to the player
+     * Helper method checking if the input entity is in proximity to an enemy
      * @param entityPos The position to center the proximity search
-     * @return True: Player is near, False: Player is not near
+     * @return True: Enemy is near, False: Enemy is not near
      */
     private boolean isNearEnemy(Point entityPos, int radius) {
         int entityRowIndex = entityPos.x;

--- a/sailinggame/src/main/java/com/group11/model/utility/AICommander.java
+++ b/sailinggame/src/main/java/com/group11/model/utility/AICommander.java
@@ -15,7 +15,6 @@ import com.group11.model.gameworld.ATile;
  * Class representing controller for AI controlled entities
  */
 public class AICommander {
-    private final int radius = 10;
     protected int innerRadius = 5;
     private List<List<AEntity>> entityMatrix;
     private List<List<Integer>> terrainMatrixEncoded;

--- a/sailinggame/src/main/java/com/group11/model/utility/AICommander.java
+++ b/sailinggame/src/main/java/com/group11/model/utility/AICommander.java
@@ -16,6 +16,7 @@ import com.group11.model.gameworld.ATile;
  */
 public class AICommander {
     private final int radius = 10;
+    private final int innerRadius = 5;
     private List<List<AEntity>> entityMatrix;
     private List<List<Integer>> terrainMatrixEncoded;
     private final int[][] directions = {{-1,0}, {-1,1}, {0,1}, {1,1}, {1,0}, {1,-1}, {0,-1}, {-1,-1}};
@@ -57,8 +58,12 @@ public class AICommander {
             if (namePosMap.containsKey("Player")) {
                 Point playerPoint = namePosMap.get("Player");
                 Point enemyPoint = enemy.getPos();
-                int directionToPlayer = AStar.aStar(this.terrainMatrixEncoded, enemyPoint.x, enemyPoint.y, playerPoint.x, playerPoint.y);
-                enemy.moveIfAble(directionToPlayer);
+                if (!this.isNearEnemy(playerPoint, this.innerRadius)) {
+                    int directionToPlayer = AStar.aStar(this.terrainMatrixEncoded, enemyPoint.x, enemyPoint.y, playerPoint.x, playerPoint.y);
+                    enemy.moveIfAble(directionToPlayer);
+                } else {
+                    enemy.moveIfAble(random.nextInt(8));
+                }
             } else {
                 enemy.moveIfAble(random.nextInt(8));
             }
@@ -67,14 +72,14 @@ public class AICommander {
 
     /**
      * Helper method checking if the input entity is in proximity to the player
-     * @param entity The entity to center the proximity search
+     * @param entityPos The position to center the proximity search
      * @return True: Player is near, False: Player is not near
      */
-    private boolean isNearPlayer(CommandableEntity entity, int radius) {
-        int entityRowIndex = entity.getBody().getPos().y;
-        int entityColumnIndex = entity.getBody().getPos().x;
+    private boolean isNearEnemy(Point entityPos, int radius) {
+        int entityRowIndex = entityPos.x;
+        int entityColumnIndex = entityPos.y;
         HashMap<String, Point> surroundingEntities = this.getSurroundingEntityNameAndPos(entityRowIndex, entityColumnIndex, radius);
-        if (surroundingEntities.containsKey("Player")) {
+        if (surroundingEntities.containsKey("Enemy")) {
             return true;
         } else {
             return false;

--- a/sailinggame/src/main/java/com/group11/model/utility/AICommander.java
+++ b/sailinggame/src/main/java/com/group11/model/utility/AICommander.java
@@ -16,7 +16,7 @@ import com.group11.model.gameworld.ATile;
  */
 public class AICommander {
     private final int radius = 10;
-    private final int innerRadius = 5;
+    protected int innerRadius = 5;
     private List<List<AEntity>> entityMatrix;
     private List<List<Integer>> terrainMatrixEncoded;
     private final int[][] directions = {{-1,0}, {-1,1}, {0,1}, {1,1}, {1,0}, {1,-1}, {0,-1}, {-1,-1}};

--- a/sailinggame/src/main/java/com/group11/model/utility/AICommander.java
+++ b/sailinggame/src/main/java/com/group11/model/utility/AICommander.java
@@ -46,6 +46,7 @@ public class AICommander {
      * This method moves the enemies in the input list based on their proximity to the player.
      * If the enemy is within the class specified radius the method runs an AStar search from the enemy
      * to the player and moves the enemy one step closer in the shortest path direction to the player.
+     * If the player has the enemy within a specified radius then the enemy will choose a random directional value
      * If the player is not in proximity than a random directional value is selected
      * @param enemies The list of enemies to move
      */

--- a/sailinggame/src/test/java/applicationtest/EntitySpawnerTest.java
+++ b/sailinggame/src/test/java/applicationtest/EntitySpawnerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
+import com.group11.model.gameentites.Ship;
 import org.junit.Test;
 
 import com.group11.application.EntitySpawner;
@@ -33,7 +34,10 @@ public class EntitySpawnerTest {
     @Test
     public void testEnemyWaveLevelOne() {
         List<CommandableEntity> enemyList = this.testSpawner.createEnemyWave(1);
-        assertEquals("Enemy: lvl 1", enemyList.get(0).getName());
+        Ship ship = ((Ship) enemyList.get(0).getBody());
+        int shipLevel = ship.getShipLevel();
+        assertEquals("Enemy", enemyList.get(0).getName());
+        assertEquals(1, shipLevel);
     }
 
     @Test
@@ -42,11 +46,12 @@ public class EntitySpawnerTest {
         int lvl2num = 0;
         int lvl1num = 0;
         for (CommandableEntity enemy : enemyList) {
-            switch (enemy.getName()) {
-                case "Enemy: lvl 1":
+            Ship ship = ((Ship) enemy.getBody());
+            switch (ship.getShipLevel()) {
+                case 1:
                     lvl1num++;
                     break;
-                case "Enemy: lvl 2":
+                case 2:
                     lvl2num++;
                     break;
             }

--- a/sailinggame/src/test/java/modeltest/AICommanderTest.java
+++ b/sailinggame/src/test/java/modeltest/AICommanderTest.java
@@ -26,6 +26,14 @@ public class AICommanderTest {
     private List<List<AEntity>> entityMatrix = UEntityMatrixGenerator.createEntityMatrix(5,5);
     private EntityDirector director = new EntityDirector(new ShipBuilder());
     private List<AEntity> entities = new ArrayList<>();
+
+    private class TestAICommander extends AICommander {
+        public TestAICommander(List<List<AEntity>> entityMatrix, List<List<ATile>> terrainMatrix) {
+            super(entityMatrix, terrainMatrix);
+            super.innerRadius = 1;
+        }
+    }
+
     @Before
     public void beforePreconditions() {
         this.grid.add(Arrays.asList(1,1,0,1,1));
@@ -85,7 +93,7 @@ public class AICommanderTest {
         this.entities.add(enemy);
         this.entities.add(this.director.createPlayer(new Point(1,2)));
         UEntityMatrixGenerator.populateEntityMatrix(this.entities, this.entityMatrix);
-        AICommander commander = new AICommander(this.entityMatrix, this.terrainMatrix);
+        TestAICommander commander = new TestAICommander(this.entityMatrix, this.terrainMatrix);
         commander.moveEnemies(enemyList);
         assertEquals(new Point(2,2), enemy.getPos());
     }
@@ -98,7 +106,7 @@ public class AICommanderTest {
         this.entities.add(enemy);
         this.entities.add(this.director.createPlayer(new Point(1,4)));
         UEntityMatrixGenerator.populateEntityMatrix(this.entities, this.entityMatrix);
-        AICommander commander = new AICommander(this.entityMatrix, this.terrainMatrix);
+        TestAICommander commander = new TestAICommander(this.entityMatrix, this.terrainMatrix);
         commander.moveEnemies(enemyList);
         assertEquals(new Point(2,3), enemy.getPos());
     }
@@ -111,7 +119,7 @@ public class AICommanderTest {
         this.entities.add(enemy);
         this.entities.add(this.director.createPlayer(new Point(2,4)));
         UEntityMatrixGenerator.populateEntityMatrix(this.entities, this.entityMatrix);
-        AICommander commander = new AICommander(this.entityMatrix, this.terrainMatrix);
+        TestAICommander commander = new TestAICommander(this.entityMatrix, this.terrainMatrix);
         commander.moveEnemies(enemyList);
         assertEquals(new Point(2,1), enemy.getPos());
     }
@@ -124,7 +132,7 @@ public class AICommanderTest {
         this.entities.add(enemy);
         this.entities.add(this.director.createPlayer(new Point(3,4)));
         UEntityMatrixGenerator.populateEntityMatrix(this.entities, this.entityMatrix);
-        AICommander commander = new AICommander(this.entityMatrix, this.terrainMatrix);
+        TestAICommander commander = new TestAICommander(this.entityMatrix, this.terrainMatrix);
         commander.moveEnemies(enemyList);
         assertEquals(new Point(1,2), enemy.getPos());
     }
@@ -137,7 +145,7 @@ public class AICommanderTest {
         this.entities.add(enemy);
         this.entities.add(this.director.createPlayer(new Point(4,4)));
         UEntityMatrixGenerator.populateEntityMatrix(this.entities, this.entityMatrix);
-        AICommander commander = new AICommander(this.entityMatrix, this.terrainMatrix);
+        TestAICommander commander = new TestAICommander(this.entityMatrix, this.terrainMatrix);
         commander.moveEnemies(enemyList);
         assertEquals(new Point(1,4), enemy.getPos());
     }
@@ -150,7 +158,7 @@ public class AICommanderTest {
         this.entities.add(enemy);
         this.entities.add(this.director.createPlayer(new Point(2,1)));
         UEntityMatrixGenerator.populateEntityMatrix(this.entities, this.entityMatrix);
-        AICommander commander = new AICommander(this.entityMatrix, this.terrainMatrix);
+        TestAICommander commander = new TestAICommander(this.entityMatrix, this.terrainMatrix);
         commander.moveEnemies(enemyList);
         assertEquals(new Point(1,2), enemy.getPos());
     }
@@ -163,7 +171,7 @@ public class AICommanderTest {
         this.entities.add(enemy);
         this.entities.add(this.director.createPlayer(new Point(2,0)));
         UEntityMatrixGenerator.populateEntityMatrix(this.entities, this.entityMatrix);
-        AICommander commander = new AICommander(this.entityMatrix, this.terrainMatrix);
+        TestAICommander commander = new TestAICommander(this.entityMatrix, this.terrainMatrix);
         commander.moveEnemies(enemyList);
         assertEquals(new Point(2,3), enemy.getPos());
     }
@@ -176,7 +184,7 @@ public class AICommanderTest {
         this.entities.add(enemy);
         this.entities.add(this.director.createPlayer(new Point(0,1)));
         UEntityMatrixGenerator.populateEntityMatrix(this.entities, this.entityMatrix);
-        AICommander commander = new AICommander(this.entityMatrix, this.terrainMatrix);
+        TestAICommander commander = new TestAICommander(this.entityMatrix, this.terrainMatrix);
         commander.moveEnemies(enemyList);
         assertEquals(new Point(2,3), enemy.getPos());
     }

--- a/sailinggame/src/test/java/modeltest/ShipBuilderTest.java
+++ b/sailinggame/src/test/java/modeltest/ShipBuilderTest.java
@@ -34,7 +34,7 @@ public class ShipBuilderTest {
         EntityDirector entityDirector = new EntityDirector(new ShipBuilder());
         AEntity enemy = entityDirector.createEnemy(new Point(0,0), 1);
         Ship body = (Ship) enemy.getBody();
-        assertEquals("Enemy: lvl 1", enemy.getName());
+        assertEquals(1, body.getShipLevel());
         assertEquals(new Point(0,0), enemy.getPos());
         assertEquals(22.5, body.getHitPoints());
         assertEquals(6.0, body.getArmor());
@@ -48,7 +48,7 @@ public class ShipBuilderTest {
         EntityDirector entityDirector = new EntityDirector(new ShipBuilder());
         AEntity enemy = entityDirector.createEnemy(new Point(0,0), 2);
         Ship body = (Ship) enemy.getBody();
-        assertEquals("Enemy: lvl 2", enemy.getName());
+        assertEquals(2, body.getShipLevel());
         assertEquals(new Point(0,0), enemy.getPos());
         assertEquals(45.0, body.getHitPoints());
         assertEquals(12.0, body.getArmor());


### PR DESCRIPTION
As a player I don't want the enemy to be able to move into and on top of me because it makes the gameplay difficult

### Result
Once the enemy has reached a certain radius around the player they will no longer move directly toward the player. Instead moving randomly around
them.